### PR TITLE
Matching Visual Studio's whitespace symbol foreground colour

### DIFF
--- a/VS2015-Dark.xml
+++ b/VS2015-Dark.xml
@@ -758,7 +758,7 @@ Note:        I don't claim any ownership of this theme. It is merely a replica o
         <WidgetStyle name="Fold" styleID="0" fgColor="A5A5A5" bgColor="1E1E1E" fontStyle="0" fontSize="" />
         <WidgetStyle name="Fold margin" styleID="0" fgColor="1E1E1E" bgColor="1E1E1E" fontStyle="0" fontSize="" />
         <WidgetStyle name="Fold active" styleID="0" fgColor="A5A5A5" bgColor="1E1E1E" fontStyle="0" />
-        <WidgetStyle name="White space symbol" styleID="0" fgColor="808080" bgColor="1E1E1E" fontStyle="0" fontSize="" />
+        <WidgetStyle name="White space symbol" styleID="0" fgColor="144852" bgColor="1E1E1E" fontStyle="0" fontSize="" />
         <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="3687E0" fgColor="B4B4B4" fontStyle="0" fontSize="" />
         <WidgetStyle name="Find Mark Style" styleID="31" bgColor="B55B0B" fgColor="B4B4B4" fontName="" fontSize="" fontStyle="0" />
         <WidgetStyle name="Mark Style 1" styleID="25" bgColor="00FFFF" fontStyle="0" fgColor="E0E2E4" />


### PR DESCRIPTION
 I noticed that the whitespace symbols are not the same as Visual Studio's. The display of these can be enabled under Notepad++'s View menu:

![image](https://user-images.githubusercontent.com/1476519/98715676-6577c200-2382-11eb-81a2-c677934665f0.png)

This PR alters the styling so that we can precisely match Visual Studio's whitespace symbol foreground colour, which is a teal colour (#144852).

**Before** (Notepad++)
![Before](https://user-images.githubusercontent.com/1476519/98715477-2184bd00-2382-11eb-8dc4-a531874cce7e.PNG)

**After** (Notepad++)
![After](https://user-images.githubusercontent.com/1476519/98715479-22b5ea00-2382-11eb-8f23-b2f50ff572df.PNG)

**Visual Studio for comparison**
![VS](https://user-images.githubusercontent.com/1476519/98715484-23e71700-2382-11eb-97a1-ec429eea0ee9.PNG)
